### PR TITLE
Add 'takamol' to project route names

### DIFF
--- a/src/export-helpers/projectRouteNames.ts
+++ b/src/export-helpers/projectRouteNames.ts
@@ -5,4 +5,5 @@ export const projectRouteNames = [
     'mercury-fraud',
     'vremenco',
     'weylchem',
+    'takamol',
 ];


### PR DESCRIPTION
Included 'takamol' to the list of project route names in projectRouteNames.ts. This change ensures that the new project route is recognized within the application.